### PR TITLE
[2020-12-28]용석: Persistence Context의 특징 예제

### DIFF
--- a/src/main/java/basic/ch01_member_crud/EX_01_MemberCreate.java
+++ b/src/main/java/basic/ch01_member_crud/EX_01_MemberCreate.java
@@ -10,9 +10,9 @@ import static basic.config.EntityManagerGenerator.generateEntityManager;
 
 /**
  * 용석 : 2020-12-28 (월)
- * EntityManager를 이용한 Mmember객체 삭제
+ * EntityManager를 이용한 Mmember객체 저장
  */
-public class MemberDelete {
+public class EX_01_MemberCreate {
 
     public static void main(String[] args) {
         EntityManager entityManager = generateEntityManager();
@@ -20,11 +20,14 @@ public class MemberDelete {
         entityTransaction.begin();
 
         long memberId = 4L;
+        String memberName = "choi-ys";
 
         try {
-            Member member = entityManager.find(Member.class, memberId);
+            Member member = new Member();
+            member.setId(memberId);
+            member.setName(memberName);
 
-            entityManager.remove(member);
+            entityManager.persist(member);
 
             entityTransaction.commit();
         } catch (Exception e) {

--- a/src/main/java/basic/ch01_member_crud/EX_02_MemberRead.java
+++ b/src/main/java/basic/ch01_member_crud/EX_02_MemberRead.java
@@ -5,32 +5,28 @@ import domain.entity.Member;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 
-import java.util.List;
-
 import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
 import static basic.config.EntityManagerGenerator.generateEntityManager;
 
 /**
  * 용석 : 2020-12-28 (월)
- * EntityManager의 JPQL을 이용한 Mmember목록 조회
+ * EntityManager를 이용한 Mmember객체 조회
  */
-public class MemberListRead {
+public class EX_02_MemberRead {
 
     public static void main(String[] args) {
         EntityManager entityManager = generateEntityManager();
         EntityTransaction entityTransaction = entityManager.getTransaction();
         entityTransaction.begin();
 
-        int offset = 0;
-        int limit = 2;
+        long memberId = 4L;
 
         try {
-            List<Member> memberList = entityManager.createQuery("select m from Member as m")
-                    .setFirstResult(offset)
-                    .setMaxResults(limit)
-                    .getResultList();
-            for (Member member : memberList){
+            Member member = entityManager.find(Member.class, memberId);
+            if(member != null){
                 System.out.println(member.getId() + " -> " + member.getName());
+            }else{
+                System.out.println("404 NotFound -> memberId : " + memberId);
             }
 
             entityTransaction.commit();
@@ -42,4 +38,5 @@ public class MemberListRead {
         }
         closeEntityManagerFactiory();
     }
+
 }

--- a/src/main/java/basic/ch01_member_crud/EX_03_MemberUpdate.java
+++ b/src/main/java/basic/ch01_member_crud/EX_03_MemberUpdate.java
@@ -10,24 +10,20 @@ import static basic.config.EntityManagerGenerator.generateEntityManager;
 
 /**
  * 용석 : 2020-12-28 (월)
- * EntityManager를 이용한 Mmember객체 조회
+ * EntityManager를 이용한 Mmember객체 수정
  */
-public class MemberRead {
+public class EX_03_MemberUpdate {
 
     public static void main(String[] args) {
         EntityManager entityManager = generateEntityManager();
         EntityTransaction entityTransaction = entityManager.getTransaction();
         entityTransaction.begin();
 
-        long memberId = 4L;
+        long memberId = 2L;
 
         try {
             Member member = entityManager.find(Member.class, memberId);
-            if(member != null){
-                System.out.println(member.getId() + " -> " + member.getName());
-            }else{
-                System.out.println("404 NotFound -> memberId : " + memberId);
-            }
+            member.setName("changed Name");
 
             entityTransaction.commit();
         } catch (Exception e) {
@@ -38,5 +34,4 @@ public class MemberRead {
         }
         closeEntityManagerFactiory();
     }
-
 }

--- a/src/main/java/basic/ch01_member_crud/EX_04_MemberDelete.java
+++ b/src/main/java/basic/ch01_member_crud/EX_04_MemberDelete.java
@@ -10,20 +10,21 @@ import static basic.config.EntityManagerGenerator.generateEntityManager;
 
 /**
  * 용석 : 2020-12-28 (월)
- * EntityManager를 이용한 Mmember객체 수정
+ * EntityManager를 이용한 Mmember객체 삭제
  */
-public class MemberUpdate {
+public class EX_04_MemberDelete {
 
     public static void main(String[] args) {
         EntityManager entityManager = generateEntityManager();
         EntityTransaction entityTransaction = entityManager.getTransaction();
         entityTransaction.begin();
 
-        long memberId = 2L;
+        long memberId = 4L;
 
         try {
             Member member = entityManager.find(Member.class, memberId);
-            member.setName("changed Name");
+
+            entityManager.remove(member);
 
             entityTransaction.commit();
         } catch (Exception e) {

--- a/src/main/java/basic/ch01_member_crud/EX_05_MemberListRead_With_JPQL.java
+++ b/src/main/java/basic/ch01_member_crud/EX_05_MemberListRead_With_JPQL.java
@@ -5,29 +5,33 @@ import domain.entity.Member;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 
+import java.util.List;
+
 import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
 import static basic.config.EntityManagerGenerator.generateEntityManager;
 
 /**
  * 용석 : 2020-12-28 (월)
- * EntityManager를 이용한 Mmember객체 저장
+ * EntityManager의 JPQL을 이용한 Mmember목록 조회
  */
-public class MemberCreate {
+public class EX_05_MemberListRead_With_JPQL {
 
     public static void main(String[] args) {
         EntityManager entityManager = generateEntityManager();
         EntityTransaction entityTransaction = entityManager.getTransaction();
         entityTransaction.begin();
 
-        long memberId = 4L;
-        String memberName = "choi-ys";
+        int offset = 0;
+        int limit = 2;
 
         try {
-            Member member = new Member();
-            member.setId(memberId);
-            member.setName(memberName);
-
-            entityManager.persist(member);
+            List<Member> memberList = entityManager.createQuery("select m from Member as m")
+                    .setFirstResult(offset)
+                    .setMaxResults(limit)
+                    .getResultList();
+            for (Member member : memberList){
+                System.out.println(member.getId() + " -> " + member.getName());
+            }
 
             entityTransaction.commit();
         } catch (Exception e) {

--- a/src/main/java/basic/ch02_persistence_context/EX_01_PersistenceContextCache.java
+++ b/src/main/java/basic/ch02_persistence_context/EX_01_PersistenceContextCache.java
@@ -1,0 +1,47 @@
+package basic.ch02_persistence_context;
+
+import domain.entity.Member;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
+import static basic.config.EntityManagerGenerator.generateEntityManager;
+
+/**
+ * 용석 : 2020-12-28 (월)
+ * EntityManager.persist(Object)를 이용한 동일 트랜잭션 범위에서의 영속성 컨텍스트의 1차 Cache 예제
+ */
+public class EX_01_PersistenceContextCache {
+
+    public static void main(String[] args) {
+        EntityManager entityManager = generateEntityManager();
+        EntityTransaction entityTransaction = entityManager.getTransaction();
+        entityTransaction.begin();
+
+        try {
+            long memberId = 9L;
+            String memberName = "choi-ys";
+            Member member = Member.builder()
+                    .id(memberId)
+                    .name(memberName)
+                    .build();
+            System.out.println("비영속 상태 [new/transient] : 객체 생성 -> " + member.toString());
+
+            entityManager.persist(member);
+            System.out.println("영속 상태 [managed] : 영속성 컨텍스트에 저장 -> Insert 쿼리 실행 전");
+
+            Member selectedMember = entityManager.find(Member.class, memberId);
+            System.out.println("영속성 컨텍스트에서 객체 조회 : DB Select 쿼리를 실행하지 않고 영속성 컨텍스트에 캐싱된 내용을 조회 -> " + selectedMember.toString());
+
+            entityTransaction.commit();
+            System.out.println("영속 상태 [managed] : Insert 쿼리 실행 및 DB Commit");
+        } catch (Exception e) {
+            entityTransaction.rollback();
+            e.printStackTrace();
+        } finally {
+            entityManager.close();
+        }
+        closeEntityManagerFactiory();
+    }
+}

--- a/src/main/java/basic/ch02_persistence_context/EX_02_PersistenceContextCacheAndIdentityComparison.java
+++ b/src/main/java/basic/ch02_persistence_context/EX_02_PersistenceContextCacheAndIdentityComparison.java
@@ -1,0 +1,41 @@
+package basic.ch02_persistence_context;
+
+import domain.entity.Member;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
+import static basic.config.EntityManagerGenerator.generateEntityManager;
+
+/**
+ * 용석 : 2020-12-28 (월)
+ * EntityManager.persist(Object)를 이용한 동일 트랜잭션 범위에서의 영속성 컨텍스트의 1차 Cache 및 동일성 보장 예제
+ */
+public class EX_02_PersistenceContextCacheAndIdentityComparison {
+
+    public static void main(String[] args) {
+        EntityManager entityManager = generateEntityManager();
+        EntityTransaction entityTransaction = entityManager.getTransaction();
+        entityTransaction.begin();
+
+        try {
+            long memberId = 9L;
+
+            Member selectedMember01 = entityManager.find(Member.class, memberId);
+            System.out.println("영속 상태 [managed] : Select 쿼리를 실행하여 영속성 컨텍스트에 1차 캐싱 -> "+selectedMember01.toString());
+
+            Member selectedMember02 = entityManager.find(Member.class, memberId);
+            System.out.println("영속성 컨텍스트에서 객체 조회 : DB Select 쿼리를 실행하지 않고 영속성 컨텍스트에 캐싱된 내용을 조회" + selectedMember02.toString());
+
+            System.out.println("동일성 비교 (identity comparison) : selectedMember01 == selectedMember02 -> " + (selectedMember01 == selectedMember02));
+            entityTransaction.commit();
+        } catch (Exception e) {
+            entityTransaction.rollback();
+            e.printStackTrace();
+        } finally {
+            entityManager.close();
+        }
+        closeEntityManagerFactiory();
+    }
+}

--- a/src/main/java/basic/ch02_persistence_context/EX_03_PersistenceContextTransactionalWriteBehind.java
+++ b/src/main/java/basic/ch02_persistence_context/EX_03_PersistenceContextTransactionalWriteBehind.java
@@ -1,0 +1,43 @@
+package basic.ch02_persistence_context;
+
+import domain.entity.Member;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
+import static basic.config.EntityManagerGenerator.generateEntityManager;
+
+/**
+ * 용석 : 2020-12-28 (월)
+ * EntityManager.persist(Object)를 이용한 영속성 컨텍스트의 트랜잭션을 지원하는 쓰기 지연 (transactional wirte-behind) 예제
+ */
+public class EX_03_PersistenceContextTransactionalWriteBehind {
+
+    public static void main(String[] args) {
+        EntityManager entityManager = generateEntityManager();
+        EntityTransaction entityTransaction = entityManager.getTransaction();
+        entityTransaction.begin();
+
+        try {
+            Member member01 = Member.builder().id(10L).name("choi-ys_01").build();
+            Member member02 = Member.builder().id(11L).name("choi-ys_02").build();
+            System.out.println("영속성 컨텍스트에 할당 전인 비영속 상태 객체 생성");
+            System.out.println("member01 -> " + member01.toString());
+            System.out.println("member02 -> " + member02.toString());
+
+            entityManager.persist(member01);
+            entityManager.persist(member02);
+            System.out.println("EntityManager.persist()를 이용하여 영속성 컨텍스트에 객체 저장 및 Insert SQL을 생성하여 쓰기 지연 저장소에 생성");
+
+            entityTransaction.commit();
+            System.out.println("EntityTransaction.commit()을 이용하여 쓰지 지연 저장소에 생성된 Insert SQL을 실행");
+        } catch (Exception e) {
+            entityTransaction.rollback();
+            e.printStackTrace();
+        } finally {
+            entityManager.close();
+        }
+        closeEntityManagerFactiory();
+    }
+}

--- a/src/main/java/basic/ch02_persistence_context/EX_04_PersistenceContextDirtyChecking.java
+++ b/src/main/java/basic/ch02_persistence_context/EX_04_PersistenceContextDirtyChecking.java
@@ -1,0 +1,41 @@
+package basic.ch02_persistence_context;
+
+import domain.entity.Member;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import static basic.config.EntityManagerGenerator.closeEntityManagerFactiory;
+import static basic.config.EntityManagerGenerator.generateEntityManager;
+
+/**
+ * 용석 : 2020-12-28 (월)
+ * JPA PersistenceContext의 변경감지 (Dirty Checking) 예제
+ */
+public class EX_04_PersistenceContextDirtyChecking {
+
+    public static void main(String[] args) {
+        EntityManager entityManager = generateEntityManager();
+        EntityTransaction entityTransaction = entityManager.getTransaction();
+        entityTransaction.begin();
+
+        try {
+            Member member = entityManager.find(Member.class, 11L);
+            System.out.println("조건에 해당하는 객체를 DB에서 조회 : " + member.toString());
+
+            member.setName("changed named");
+            System.out.println("조회한 객체의 필드 중 일부를 변경 : " + member.toString());
+
+            entityTransaction.commit();
+            System.out.println("변경 사항을 Commit 하는 시점에 영속성 컨텍스트에 최초에 캐싱된 스냅샷과 Commit 시점의 값을 비교");
+            System.out.println("객체의 스냅샷과 Commit 시점의 객체의 값이 다른경우 Update SQL을 쓰기 지연 저장소에 생성 및 SQL 실행");
+            System.out.println("Commit 이후 변경 된 member 객체의 값 : " + member.toString());
+        } catch (Exception e) {
+            entityTransaction.rollback();
+            e.printStackTrace();
+        } finally {
+            entityManager.close();
+        }
+        closeEntityManagerFactiory();
+    }
+}

--- a/src/main/java/domain/entity/Member.java
+++ b/src/main/java/domain/entity/Member.java
@@ -3,14 +3,17 @@ package domain.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
 @Getter
 @Setter
 @Builder
+@ToString
 public class Member {
 
     @Id

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -16,6 +16,8 @@
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.format_sql" value="true"/>
             <property name="hibernate.use_sql_comments" value="true"/>
+            <!-- 쓰기 지연 옵션 -->
+            <property name="hibernate.jdbc.batch_size" value="10"/>
             <!--<property name="hibernate.hbm2ddl.auto" value="create" />-->
         </properties>
     </persistence-unit>


### PR DESCRIPTION
 - 동일 트랜잭션 범위내에서의 캐싱
   - Persistence Context에 저장된 캐시 조회 예제

 - 동일 트랜잭션 범위내에서의 동일성 보장
   - Persistence Context에 캐싱된 Entity의 동일성 비교 예제

 - 트랜잭션을 지원하는 쓰기 지연 : transactional wirte-behind
   - EntityTransaction.commit() 시점에 쓰기 지연 SQL 저장소에 저장된 SQL 실행 예제

 - 동일 트랜잭션 범위내에서의 변경감지 : Dirty Checking
   - EntityTransaction.commit() 시점에 Persistence Context에 최초에 캐싱된 스냅샷과 Entity의 값이 다른 경우 쓰기 지연 SQL 저장소에 저장된 Update SQL 실행 예제